### PR TITLE
Adaptive Triangle Filtering

### DIFF
--- a/src/neural_mesh_simplification/models/edge_predictor.py
+++ b/src/neural_mesh_simplification/models/edge_predictor.py
@@ -18,6 +18,9 @@ class EdgePredictor(nn.Module):
         self.W_k = nn.Linear(hidden_channels, hidden_channels, bias=False)
 
     def forward(self, x, edge_index):
+        if edge_index.numel() == 0:
+            raise ValueError("Edge index is empty")
+
         # Step 1: Extend original mesh connectivity with k-nearest neighbors
         knn_edges = knn_graph(x, k=self.k, flow="target_to_source")
 
@@ -48,6 +51,9 @@ class EdgePredictor(nn.Module):
         return simplified_adj_indices, simplified_adj_values
 
     def compute_attention_scores(self, features, edges):
+        if edges.numel() == 0:
+            raise ValueError("Edge index is empty")
+
         row, col = edges
         q = self.W_q(features)
         k = self.W_k(features)
@@ -61,6 +67,9 @@ class EdgePredictor(nn.Module):
         return attention_scores
 
     def compute_simplified_adjacency(self, attention_scores, edge_index):
+        if edge_index.numel() == 0:
+            raise ValueError("Edge index is empty")
+
         num_nodes = edge_index.max().item() + 1
         row, col = edge_index
 

--- a/src/neural_mesh_simplification/models/edge_predictor.py
+++ b/src/neural_mesh_simplification/models/edge_predictor.py
@@ -18,12 +18,6 @@ class EdgePredictor(nn.Module):
         self.W_k = nn.Linear(hidden_channels, hidden_channels, bias=False)
 
     def forward(self, x, edge_index):
-        # Handle the case when edge_index is empty
-        if edge_index.numel() == 0:
-            return torch.empty((2, 0), dtype=torch.long, device=x.device), torch.empty(
-                0, device=x.device
-            )
-
         # Step 1: Extend original mesh connectivity with k-nearest neighbors
         knn_edges = knn_graph(x, k=self.k, flow="target_to_source")
 
@@ -54,9 +48,6 @@ class EdgePredictor(nn.Module):
         return simplified_adj_indices, simplified_adj_values
 
     def compute_attention_scores(self, features, edges):
-        if edges.numel() == 0:
-            return torch.empty(0, device=features.device)
-
         row, col = edges
         q = self.W_q(features)
         k = self.W_k(features)
@@ -70,11 +61,6 @@ class EdgePredictor(nn.Module):
         return attention_scores
 
     def compute_simplified_adjacency(self, attention_scores, edge_index):
-        if edge_index.numel() == 0:
-            return torch.empty(
-                (2, 0), dtype=torch.long, device=edge_index.device
-            ), torch.empty(0, device=edge_index.device)
-
         num_nodes = edge_index.max().item() + 1
         row, col = edge_index
 

--- a/src/neural_mesh_simplification/models/edge_predictor.py
+++ b/src/neural_mesh_simplification/models/edge_predictor.py
@@ -24,9 +24,21 @@ class EdgePredictor(nn.Module):
                 0, device=x.device
             )
 
-        # Step 1: Extend original mesh connectivity
+        # Step 1: Extend original mesh connectivity with k-nearest neighbors
         knn_edges = knn_graph(x, k=self.k, flow="target_to_source")
-        extended_edges = torch.cat([edge_index, knn_edges], dim=1)
+
+        # Ensure knn_edges indices are within bounds
+        max_idx = x.size(0) - 1
+        valid_edges = (knn_edges[0] <= max_idx) & (knn_edges[1] <= max_idx)
+        knn_edges = knn_edges[:, valid_edges]
+
+        # Combine original edges with knn edges
+        if edge_index.numel() > 0:
+            extended_edges = torch.cat([edge_index, knn_edges], dim=1)
+            # Remove duplicate edges
+            extended_edges = torch.unique(extended_edges, dim=1)
+        else:
+            extended_edges = knn_edges
 
         # Step 2: Apply DevConv
         features = self.devconv(x, extended_edges)
@@ -42,6 +54,9 @@ class EdgePredictor(nn.Module):
         return simplified_adj_indices, simplified_adj_values
 
     def compute_attention_scores(self, features, edges):
+        if edges.numel() == 0:
+            return torch.empty(0, device=features.device)
+
         row, col = edges
         q = self.W_q(features)
         k = self.W_k(features)
@@ -60,7 +75,7 @@ class EdgePredictor(nn.Module):
                 (2, 0), dtype=torch.long, device=edge_index.device
             ), torch.empty(0, device=edge_index.device)
 
-        num_nodes = attention_scores.size(0)
+        num_nodes = edge_index.max().item() + 1
         row, col = edge_index
 
         # Ensure indices are within bounds

--- a/src/neural_mesh_simplification/models/neural_mesh_simplification.py
+++ b/src/neural_mesh_simplification/models/neural_mesh_simplification.py
@@ -89,7 +89,10 @@ class NeuralMeshSimplification(nn.Module):
                 (0, 3), dtype=torch.long, device=data.x.device
             )
         else:
-            simplified_faces = candidate_triangles[triangle_probs > 0.5]
+            threshold = torch.quantile(
+                triangle_probs, 1 - self.target_ratio
+            )  # Use a dynamic threshold
+            simplified_faces = candidate_triangles[triangle_probs > threshold]
 
         return {
             "sampled_indices": sampled_indices,

--- a/src/neural_mesh_simplification/models/neural_mesh_simplification.py
+++ b/src/neural_mesh_simplification/models/neural_mesh_simplification.py
@@ -90,9 +90,9 @@ class NeuralMeshSimplification(nn.Module):
             )
         else:
             threshold = torch.quantile(
-                triangle_probs, 1 - self.target_ratio
+                face_probs, 1 - self.target_ratio
             )  # Use a dynamic threshold
-            simplified_faces = candidate_triangles[triangle_probs > threshold]
+            simplified_faces = candidate_triangles[face_probs > threshold]
 
         return {
             "sampled_indices": sampled_indices,

--- a/tests/test_edge_predictor.py
+++ b/tests/test_edge_predictor.py
@@ -38,7 +38,7 @@ def test_edge_predictor_forward(sample_mesh_data):
     assert isinstance(simplified_adj_values, torch.Tensor)
     assert simplified_adj_indices.shape[0] == 2  # 2 rows for source and target indices
     assert (
-            simplified_adj_values.shape[0] == simplified_adj_indices.shape[1]
+        simplified_adj_values.shape[0] == simplified_adj_indices.shape[1]
     )  # Same number of values as edges
 
 
@@ -135,17 +135,15 @@ def test_empty_input_handling():
     empty_edge_index = torch.empty((2, 0), dtype=torch.long)
 
     # Test forward pass with empty edge_index
-    indices, values = edge_predictor(x, empty_edge_index)
-    assert indices.shape == (2, 0)
-    assert values.shape == (0,)
+    with pytest.raises(ValueError, match="Edge index is empty"):
+        indices, values = edge_predictor(x, empty_edge_index)
 
     # Test compute_simplified_adjacency with empty edge_index
     empty_attention_scores = torch.empty(0)
-    indices, values = edge_predictor.compute_simplified_adjacency(
-        empty_attention_scores, empty_edge_index
-    )
-    assert indices.shape == (2, 0)
-    assert values.shape == (0,)
+    with pytest.raises(ValueError, match="Edge index is empty"):
+        indices, values = edge_predictor.compute_simplified_adjacency(
+            empty_attention_scores, empty_edge_index
+        )
 
 
 def test_feature_transformation():


### PR DESCRIPTION
This ensures that the top `target_ratio` of triangles are always retained, making the selection adaptive to different probability distributions.

The fixed 0.5 threshold could remove too many or too few triangles, depending on the probability distribution. Using a quantile ensures adaptive filtering, making results more stable.